### PR TITLE
Suppresses jshint warnings about comma-first coding style

### DIFF
--- a/jquery.backstretch.js
+++ b/jquery.backstretch.js
@@ -2,6 +2,8 @@
 * http://srobbin.com/jquery-plugins/backstretch/
 * Copyright (c) 2013 Scott Robbin; Licensed MIT */
 
+/* jshint laxcomma:true */
+
 ;(function ($, window, undefined) {
   'use strict';
 


### PR DESCRIPTION
When validating `jquery.backstretch.js` via http://jshint.com/ it complains about the commas.

`laxcomma:true` suppresses this warnings: http://jshint.com/docs/options/#laxcomma